### PR TITLE
Enable default sender to be set via ENV

### DIFF
--- a/config/initializers/mno_enterprise.rb
+++ b/config/initializers/mno_enterprise.rb
@@ -32,7 +32,7 @@ MnoEnterprise.configure do |config|
 
   # Default sender for system generated emails
   config.default_sender_name = 'My Company'
-  config.default_sender_email = 'no-reply@example.com'
+  config.default_sender_email = ENV['default_sender_email'] || 'no-reply@example.com'
 
   #===============================================
   # External Routes


### PR DESCRIPTION
This demo is deployed in various environments, that allow to customise
it without code changes.